### PR TITLE
fix: getCurrentMember 500 에러 수정

### DIFF
--- a/frontend/src/components/common/header.jsx
+++ b/frontend/src/components/common/header.jsx
@@ -30,15 +30,23 @@ function Header() {
     };
 
     useEffect(() => {
-        async function a() {
-            try {
-                const value = await axios.get(`/api/member/email`);
-                setIsLoggedIn(true);
-            } catch (err) {
-                setIsLoggedIn(false);
-            }
-        }
-        a();
+        axios.get(`/api/member/email`)
+            .then((res) => {
+                console.log(res);
+                console.log(res.data.id == null);
+                setIsLoggedIn(res.data.id !== null);
+            });
+
+        // async function a() {
+        //     try {
+        //         const value = await axios.get(`/api/member/email`);
+        //         setIsLoggedIn(true);
+        //     } catch (err) {
+        //         setIsLoggedIn(false);
+        //     }
+        // }
+        //
+        // a();
     }, []);
 
     return (

--- a/src/main/java/com/user/IntArea/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/user/IntArea/common/exception/GlobalExceptionHandler.java
@@ -1,20 +1,16 @@
 package com.user.IntArea.common.exception;
 
+import com.user.IntArea.common.exception.custom.LoginInfoNotFoundException;
 import com.user.IntArea.common.exception.custom.UserAlreadyExistsException;
+import com.user.IntArea.dto.member.MemberResponseDto;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.validation.FieldError;
-import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 
 @RestControllerAdvice
@@ -42,5 +38,11 @@ public class GlobalExceptionHandler {
 //        e.getBindingResult().getAllErrors()
 //                .forEach(c -> errors.put(((FieldError) c).getField(), c.getDefaultMessage()));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+    // 로그인 정보가 없을 때, 200번대와 함께 loginInfoDto 반환
+    @ExceptionHandler(LoginInfoNotFoundException.class)
+    protected ResponseEntity<MemberResponseDto> handleDuplicateKeyException(LoginInfoNotFoundException e) {
+        return ResponseEntity.ok().body(e.getMemberResponseDto());
     }
 }

--- a/src/main/java/com/user/IntArea/common/exception/custom/LoginInfoNotFoundException.java
+++ b/src/main/java/com/user/IntArea/common/exception/custom/LoginInfoNotFoundException.java
@@ -1,0 +1,17 @@
+package com.user.IntArea.common.exception.custom;
+
+import com.user.IntArea.dto.member.MemberResponseDto;
+import lombok.Getter;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@Getter
+public class LoginInfoNotFoundException extends UsernameNotFoundException {
+
+    private final MemberResponseDto memberResponseDto;
+
+    public LoginInfoNotFoundException(MemberResponseDto memberResponseDto) {
+        super("로그인 정보가 없습니다.");
+        this.memberResponseDto = memberResponseDto;
+    }
+
+}

--- a/src/main/java/com/user/IntArea/common/utils/SecurityUtil.java
+++ b/src/main/java/com/user/IntArea/common/utils/SecurityUtil.java
@@ -17,12 +17,11 @@ public class SecurityUtil {
     public static Optional<MemberDto> getCurrentMember() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null) {
+        if (authentication == null || !(authentication.getPrincipal() instanceof UserDetails userDetails)) {
             log.debug("Security Context에 인증 정보가 없습니다.");
             return Optional.empty();
         }
 
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         String role = String.valueOf(userDetails.getAuthorities().stream().findFirst()
                 .orElseThrow(() -> new UsernameNotFoundException("로그인 정보가 없습니다. 다시 시도해주세요.")));
 

--- a/src/main/java/com/user/IntArea/dto/member/MemberResponseDto.java
+++ b/src/main/java/com/user/IntArea/dto/member/MemberResponseDto.java
@@ -3,17 +3,16 @@ package com.user.IntArea.dto.member;
 import com.user.IntArea.entity.Member;
 import com.user.IntArea.entity.enums.Platform;
 import com.user.IntArea.entity.enums.Role;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Data
+@NoArgsConstructor
 public class MemberResponseDto {
 
     private UUID id;

--- a/src/main/java/com/user/IntArea/service/MemberService.java
+++ b/src/main/java/com/user/IntArea/service/MemberService.java
@@ -1,11 +1,9 @@
 package com.user.IntArea.service;
 
+import com.user.IntArea.common.exception.custom.LoginInfoNotFoundException;
 import com.user.IntArea.common.exception.custom.UserAlreadyExistsException;
 import com.user.IntArea.common.utils.SecurityUtil;
-import com.user.IntArea.dto.member.MemberDto;
-import com.user.IntArea.dto.member.MemberRequestDto;
-import com.user.IntArea.dto.member.MemberResponseDto;
-import com.user.IntArea.dto.member.UpdateMemberDto;
+import com.user.IntArea.dto.member.*;
 import com.user.IntArea.entity.Member;
 import com.user.IntArea.entity.enums.Platform;
 import com.user.IntArea.entity.enums.Role;
@@ -79,10 +77,10 @@ public class MemberService {
 
     public MemberResponseDto getMemberByEmail() {
         MemberDto memberDto = SecurityUtil.getCurrentMember()
-                .orElseThrow(() -> new UsernameNotFoundException("현재 로그인한 사용자가 없습니다."));
+                .orElseThrow(() -> new LoginInfoNotFoundException(new MemberResponseDto()));
         String email = memberDto.getEmail();
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일로 회원을 찾을 수 없습니다."));
+                .orElseThrow(() -> new LoginInfoNotFoundException(new MemberResponseDto()));
 
         // Member를 MemberResponseDto로 변환하여 반환
         return new MemberResponseDto(member);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[✔] 버그 수정
-[] 테스트 코드
-[] 스타일 및 CSS 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[] README, markdown 수정
-[] 기타

### 반영 브랜치

ex) feat/login -> dev

### 변경 사항

getCurrentMember() 호출 시, 로그인 정보가 없으면 에러가 나는 것을 수정했습니다.
로그인 정보가 없을 시, statusCode 200과 함께 id = null인 MemberResponseDto를 return 하도록 수정했습니다.

### 테스트 결과
