### PR TITLE
feat: OAuth2 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,13 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
     compileOnly 'org.projectlombok:lombok'

--- a/frontend/src/pages/login/login.jsx
+++ b/frontend/src/pages/login/login.jsx
@@ -15,12 +15,24 @@ function Login() {
     const submit = (e) => {
         e.preventDefault(); // 기본 폼 제출 방지
         const {email, password} = login;
-        axios.post('/api/member/login', {email, password},{withCredentials: true})
+        axios.post('/api/member/login', {email, password}, {withCredentials: true})
             .then(res => {
                 alert("login Success");
                 navigate("/");
             })
             .catch(err => alert(err.response ? err.response.data.message : "로그인 실패"));
+    }
+
+    const naverLogin = () => {
+        window.location.href = "http://localhost:8080/oauth2/authorization/naver";
+    }
+
+    const googleLogin = () => {
+        window.location.href = "http://localhost:8080/oauth2/authorization/google"
+    }
+
+    const kakaoLogin = () => {
+        window.location.href = "http://localhost:8080/oauth2/authorization/kakao"
     }
 
     return <>
@@ -31,7 +43,7 @@ function Login() {
                 </Link>
                 <form method="post" onKeyDown={(event) => {
                     const key = event.key;
-                    if(key === 'Enter') {
+                    if (key === 'Enter') {
                         submit(event);
                     }
                 }}>
@@ -65,6 +77,17 @@ function Login() {
                         <div className={style['others']}>
                             <Link to="/signup">회원가입</Link>
                         </div>
+                    </div>
+                    <div>
+                        <Button variant="outlined" onClick={naverLogin}>
+                            네이버 로그인
+                        </Button>
+                        <Button variant="outlined" onClick={googleLogin}>
+                            구글 로그인
+                        </Button>
+                        <Button variant="outlined" onClick={kakaoLogin}>
+                            카카오 로그인
+                        </Button>
                     </div>
                 </form>
             </div>

--- a/src/main/java/com/user/IntArea/common/oauth/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/user/IntArea/common/oauth/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,35 @@
+package com.user.IntArea.common.oauth;
+
+import com.user.IntArea.common.jwt.TokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Value("${client.url}")
+    String clientUrl;
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        response.addCookie(tokenProvider.getAccessServletCookie(authentication));
+        response.addCookie(tokenProvider.getLoginServletCookie());
+
+        // http://localhost:808? 를 얻기 위한 코드 (개발 편의를 위한 코드, 배포 시 제거 필요)
+        String requestUrl = request.getRequestURL().substring(0, 21);
+        // 배포 시 clientUrl 로 변경
+        response.sendRedirect(requestUrl);
+    }
+}

--- a/src/main/java/com/user/IntArea/common/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/user/IntArea/common/oauth/CustomOAuth2User.java
@@ -1,0 +1,36 @@
+package com.user.IntArea.common.oauth;
+
+import com.user.IntArea.common.oauth.dto.MemberOAuth2Dto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final MemberOAuth2Dto memberOAuth2Dto;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(memberOAuth2Dto.getRole().getRole()));
+    }
+
+    @Override
+    public String getName() {
+        return memberOAuth2Dto.getEmail();
+    }
+
+    public String getUsername() {
+        return memberOAuth2Dto.getUsername();
+    }
+}

--- a/src/main/java/com/user/IntArea/common/oauth/dto/GoogleResponse.java
+++ b/src/main/java/com/user/IntArea/common/oauth/dto/GoogleResponse.java
@@ -1,0 +1,39 @@
+package com.user.IntArea.common.oauth.dto;
+
+import com.user.IntArea.entity.enums.Platform;
+
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response {
+
+    private final Map<String, Object> attribute;
+
+    public GoogleResponse(Map<String, Object> attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+
+    @Override
+    public Platform getPlatform() {
+        return Platform.GOOGLE;
+    }
+}

--- a/src/main/java/com/user/IntArea/common/oauth/dto/KakaoResponse.java
+++ b/src/main/java/com/user/IntArea/common/oauth/dto/KakaoResponse.java
@@ -1,0 +1,40 @@
+package com.user.IntArea.common.oauth.dto;
+
+import com.user.IntArea.entity.enums.Platform;
+
+import java.util.Map;
+
+public class KakaoResponse implements OAuth2Response {
+
+    private final Map<String, Object> attribute;
+
+    public KakaoResponse(Map<String, Object> attribute) {
+        this.attribute = (Map<String, Object>) attribute.get("kakao_account");
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> profile = (Map<String, Object>) attribute.get("profile");
+        return profile.get("nickname").toString();
+    }
+
+    @Override
+    public Platform getPlatform() {
+        return Platform.KAKAO;
+    }
+}

--- a/src/main/java/com/user/IntArea/common/oauth/dto/MemberOAuth2Dto.java
+++ b/src/main/java/com/user/IntArea/common/oauth/dto/MemberOAuth2Dto.java
@@ -1,0 +1,14 @@
+package com.user.IntArea.common.oauth.dto;
+
+import com.user.IntArea.entity.enums.Role;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberOAuth2Dto {
+
+    private String email;
+    private String username;
+    private Role role;
+}

--- a/src/main/java/com/user/IntArea/common/oauth/dto/NaverResponse.java
+++ b/src/main/java/com/user/IntArea/common/oauth/dto/NaverResponse.java
@@ -1,0 +1,39 @@
+package com.user.IntArea.common.oauth.dto;
+
+import com.user.IntArea.entity.enums.Platform;
+
+import java.util.Map;
+
+public class NaverResponse implements OAuth2Response{
+
+    private final Map<String, Object> attribute;
+
+    public NaverResponse(Map<String, Object> attribute) {
+        this.attribute = (Map<String, Object>) attribute.get("response");
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+
+    @Override
+    public Platform getPlatform() {
+        return Platform.NAVER;
+    }
+}

--- a/src/main/java/com/user/IntArea/common/oauth/dto/OAuth2Response.java
+++ b/src/main/java/com/user/IntArea/common/oauth/dto/OAuth2Response.java
@@ -1,0 +1,16 @@
+package com.user.IntArea.common.oauth.dto;
+
+import com.user.IntArea.entity.enums.Platform;
+
+public interface OAuth2Response {
+
+    String getProvider();
+
+    String getProviderId();
+
+    String getEmail();
+
+    String getName();
+
+    Platform getPlatform();
+}

--- a/src/main/java/com/user/IntArea/config/SecurityConfig.java
+++ b/src/main/java/com/user/IntArea/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import com.user.IntArea.common.jwt.JwtSecurityConfig;
 import com.user.IntArea.common.jwt.TokenProvider;
 import com.user.IntArea.common.jwt.error.JwtAccessDeniedHandler;
 import com.user.IntArea.common.jwt.error.JwtAuthenticationEntryPoint;
+import com.user.IntArea.common.oauth.CustomOAuth2SuccessHandler;
+import com.user.IntArea.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +31,8 @@ public class SecurityConfig {
     private final TokenProvider tokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -53,7 +57,7 @@ public class SecurityConfig {
         // 인증이 필요하지 않은 Get이 아닌 api
         String[] companyApi = {};
         String[] imageApi = {};
-        String[] memberApi = {"/api/member/login", "/api/member/signup"};
+        String[] memberApi = {"/api/member/login", "/api/member/signup", "/api/oauth2/**"};
         String[] duplicationApi = {"/api/duplication/email", "/api/duplication/username"};
         String[] portfolioApi = {};
         String[] quotationApi = {};
@@ -114,16 +118,25 @@ public class SecurityConfig {
 
                 // token을 사용하는 방식이기 때문에 csrf disable
                 .csrf(AbstractHttpConfigurer::disable)
-
-                .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
 
                 // 세션을 사용하지 않기 때문에 STATELESS로 설정
                 .sessionManagement(sessionManagement ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
 
+                .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+
                 .with(new JwtSecurityConfig(tokenProvider), customizer -> {
                 })
+
+                .oauth2Login(oauth2 -> oauth2
+                        .redirectionEndpoint(redirect -> redirect
+                                .baseUri("/api/login/oauth2/code/*"))
+                        .userInfoEndpoint(userinfo -> userinfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(customOAuth2SuccessHandler))
 
                 .exceptionHandling(exceptionHandling -> exceptionHandling
                         .accessDeniedHandler(jwtAccessDeniedHandler)

--- a/src/main/java/com/user/IntArea/controller/MemberController.java
+++ b/src/main/java/com/user/IntArea/controller/MemberController.java
@@ -43,7 +43,7 @@ public class MemberController {
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        ResponseCookie accessToken = tokenProvider.createAccessToken(authentication);
+        ResponseCookie accessToken = tokenProvider.getAccessToken(authentication);
         ResponseCookie loginToken = tokenProvider.getLoginToken();
 
         return ResponseEntity.ok()

--- a/src/main/java/com/user/IntArea/entity/enums/Platform.java
+++ b/src/main/java/com/user/IntArea/entity/enums/Platform.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum Platform {
     KAKAO("KAKAO"),
+    NAVER("NAVER"),
+    GOOGLE("GOOGLE"),
     SERVER("SERVER");
 
     private final String platform;

--- a/src/main/java/com/user/IntArea/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/user/IntArea/service/CustomOAuth2UserService.java
@@ -1,0 +1,73 @@
+package com.user.IntArea.service;
+
+import com.user.IntArea.common.oauth.CustomOAuth2User;
+import com.user.IntArea.common.oauth.dto.*;
+import com.user.IntArea.entity.Member;
+import com.user.IntArea.entity.enums.Role;
+import com.user.IntArea.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response;
+
+        switch (registrationId) {
+            case "naver" -> oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+            case "google" -> oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+            case "kakao" -> oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
+            default -> {
+                return null;
+            }
+        }
+
+        Optional<Member> optionalMember = memberRepository.findByEmail(oAuth2Response.getEmail());
+        Member member;
+        if (optionalMember.isEmpty()) {
+
+            // 회원 정보가 없는 경우 저장
+            member = Member.builder()
+                    .email(oAuth2Response.getEmail())
+                    .username(oAuth2Response.getName())
+                    .password(UUID.randomUUID().toString())
+                    .role(Role.ROLE_USER)
+                    .platform(oAuth2Response.getPlatform())
+                    .build();
+
+            memberRepository.save(member);
+        } else {
+
+            // 변경사항만 업데이트
+            member = optionalMember.get();
+
+            member.setUsername(oAuth2Response.getName());
+            member.setPlatform(oAuth2Response.getPlatform());
+            memberRepository.save(member);
+        }
+
+        MemberOAuth2Dto memberOAuth2Dto = MemberOAuth2Dto.builder()
+                .email(member.getEmail())
+                .username(member.getUsername())
+                .role(member.getRole())
+                .build();
+
+        return new CustomOAuth2User(memberOAuth2Dto);
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[✔] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 테스트 코드
-[] 스타일 및 CSS 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[] README, markdown 수정
-[] 기타

### 반영 브랜치

ex) feat/login -> dev

### 변경 사항

- 네이버, 구글, 카카오 로그인 구현 
  - 로그인 페이지에 버튼 임시 구현
  - 현재 네이버는 테스터 등록한 계정만 로그인 가능
- 동일 이메일이 있는 경우, member 테이블 platform 변경하도록 작성 (platform 여러개 적용 논의 필요)
- jjwt 0.11.5 -> 0.12.6 마이그레이션

### 테스트 결과
